### PR TITLE
Add a timeout to `fetch()` + configurable environment variable

### DIFF
--- a/bin/ncm-ci.js
+++ b/bin/ncm-ci.js
@@ -9,7 +9,9 @@ const fetch = require('node-fetch')
 
 // Setting up a timeout to be used with fetch() – will use the NCM_TIMEOUT environment
 // variable or default to 2 minutes (120 seconds / 120000 milliseconds)
-let NCM_TIMEOUT = process.env.NCM_TIMEOUT ? process.env.NCM_TIMEOUT : 120000
+const timeout = process.env.NCM_TIMEOUT
+  ? Number(process.env.NCM_TIMEOUT) * 1000
+  : 120000
 
 if (!process.env.NCM_TOKEN) {
   console.error(`

--- a/bin/ncm-ci.js
+++ b/bin/ncm-ci.js
@@ -7,6 +7,10 @@ const graphql = require('../lib/graphql')
 const chalk = require('chalk')
 const fetch = require('node-fetch')
 
+// Setting up a timeout to be used with fetch() – will use the NCM_TIMEOUT environment
+// variable or default to 2 minutes (120 seconds / 120000 milliseconds)
+let NCM_TIMEOUT = process.env.NCM_TIMEOUT ? process.env.NCM_TIMEOUT : 120000;
+
 if (!process.env.NCM_TOKEN) {
   console.error(`
     Usage
@@ -49,7 +53,8 @@ const getUserDetails = async () => {
   const res = await fetch(`${api.accounts}/user/details`, {
     headers: {
       Authorization: `Bearer ${token}`
-    }
+    },
+    timeout: NCM_TIMEOUT
   })
   const details = await res.json()
   if (

--- a/bin/ncm-ci.js
+++ b/bin/ncm-ci.js
@@ -56,7 +56,7 @@ const getUserDetails = async () => {
     headers: {
       Authorization: `Bearer ${token}`
     },
-    timeout: NCM_TIMEOUT
+    timeout
   })
   const details = await res.json()
   if (

--- a/bin/ncm-ci.js
+++ b/bin/ncm-ci.js
@@ -9,7 +9,7 @@ const fetch = require('node-fetch')
 
 // Setting up a timeout to be used with fetch() – will use the NCM_TIMEOUT environment
 // variable or default to 2 minutes (120 seconds / 120000 milliseconds)
-let NCM_TIMEOUT = process.env.NCM_TIMEOUT ? process.env.NCM_TIMEOUT : 120000;
+let NCM_TIMEOUT = process.env.NCM_TIMEOUT ? process.env.NCM_TIMEOUT : 120000
 
 if (!process.env.NCM_TOKEN) {
   console.error(`


### PR DESCRIPTION
This PR adds a timeout to the `fetch()` call in `/bin/ncm-ci.js`. Also adds the `NCM_TIMEOUT` environment variable, which can be used to set a custom timeout time (2 minutes by default).